### PR TITLE
Fixed bug that was causing the didSelectCell call to not be called when it should have been

### DIFF
--- a/PSCollectionView.m
+++ b/PSCollectionView.m
@@ -262,7 +262,7 @@ static inline NSInteger PSCollectionIndexForKey(NSString *key) {
             CGFloat top = [[colOffsets objectAtIndex:col] floatValue];
             CGFloat colHeight = [self.collectionViewDataSource collectionView:self heightForRowAtIndex:i];
             
-            CGRect viewRect = CGRectMake(left, top, self.colWidth, colHeight);
+            CGRect viewRect = CGRectIntegral(CGRectMake(left, top, self.colWidth, colHeight));
             
             // Add to index rect map
             [self.indexToRectMap setObject:NSStringFromCGRect(viewRect) forKey:key];


### PR DESCRIPTION
... rect through CGRectIntegral because the rect created and passed into the indexToRectMap sometimes would not match the actual rect created for the view when the NSStringFromCGRect call was subsequently made in the - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch and - (void)didSelectView:(UITapGestureRecognizer *)gestureRecognizer due to rounding that sometimes occurred.  This ultimately ended up in the - (void)collectionView:(PSCollectionView *)collectionView didSelectCell:(PSCollectionViewCell *)cell atIndex:(NSInteger)index not being called when a cell actually had been tapped.
